### PR TITLE
[Fix] 챌린지 상세에서 인증, 인증글볼 때 해당 다른 챌린지 보이던 현상 개선

### DIFF
--- a/Cider/Cider/Presentation/Certify/ViewModels/CertifyViewModel.swift
+++ b/Cider/Cider/Presentation/Certify/ViewModels/CertifyViewModel.swift
@@ -29,16 +29,19 @@ final class CertifyViewModel: ViewModelType {
     
     var challengeList: [String] = []
     var challengeIds: [Int] = []
-    var challengeIndex: Int = 0
+    var selectedChallengeIndex: Int = 0
+    lazy var selectedChallengeTitle: String = challengeList.first ?? ""
     lazy var challengeName = challengeNamePlaceHolder
     lazy var challengeContent = challengeContentPlaceHolder
     var certifyImage: UIImage?
+    private var selectedChallengeId: Int?
     
     var challengeNamePlaceHolder = "오늘 인증 완료!"
     var challengeContentPlaceHolder = "인증에 대한 이야기와 다양한 생각들, 사진에 대한 설명을 작성해보세요!"
     
-    init(usecase: CertifyUsecase) {
+    init(usecase: CertifyUsecase, selectedChallengeId: Int?) {
         self.usecase = usecase
+        self.selectedChallengeId = selectedChallengeId
     }
     
     func viewDidLoad() {
@@ -66,7 +69,7 @@ final class CertifyViewModel: ViewModelType {
     }
     
     func selectChallengeIndex(_ challengeIndex: Int) {
-        self.challengeIndex = challengeIndex
+        self.selectedChallengeIndex = challengeIndex
         currentState.send(.changeNextButtonState(isAvailableNextButton()))
     }
     
@@ -82,7 +85,7 @@ private extension CertifyViewModel {
     func upload() {
         Task {
             let request = CertifyRequest(
-                challengeId: challengeIds[challengeIndex],
+                challengeId: challengeIds[selectedChallengeIndex],
                 certifyName: challengeName,
                 certifyContent: challengeContent
             )
@@ -112,12 +115,21 @@ private extension CertifyViewModel {
                 challengeList.append(challenge.challengeName)
                 challengeIds.append(challenge.challengeId)
             }
+            if let selectedChallengeId {
+                for i in 0..<challengeIds.count {
+                    if selectedChallengeId == challengeIds[i] {
+                        selectedChallengeIndex = i
+                        selectedChallengeTitle = challengeList[i]
+                        break
+                    }
+                }
+            }
             currentState.send(.applySnapshot)
         }
     }
     
     func isAvailableNextButton() -> Bool {
-        print(challengeName, challengeIndex, challengeContent, certifyImage)
+        print(challengeName, selectedChallengeIndex, challengeContent, certifyImage)
 
         guard challengeName != challengeNamePlaceHolder,
               challengeContent != challengeContentPlaceHolder,

--- a/Cider/Cider/Presentation/Certify/Views/CertifyViewController.swift
+++ b/Cider/Cider/Presentation/Certify/Views/CertifyViewController.swift
@@ -132,7 +132,7 @@ private extension CertifyViewController {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CertifyCell.identifier, for: indexPath) as? CertifyCell else {
                 return UICollectionViewCell()
             }
-            cell.challengeSelectionView.setTextFieltText(self.viewModel.challengeList.first ?? "")
+            cell.challengeSelectionView.setTextFieltText(self.viewModel.selectedChallengeTitle)
             cell.addTapGestureCameraView(self, action: #selector(self.didTapCameraView))
             cell.setCameraImage(self.viewModel.certifyImage)
             cell.titleTextFieldView.textPublisher()
@@ -164,7 +164,7 @@ private extension CertifyViewController {
                 }
                 .store(in: &self.cancellables)
             cell.challengeSelectionView.challengeList = self.viewModel.challengeList
-            cell.challengeSelectionView.selectedIndex = self.viewModel.challengeIndex
+            cell.challengeSelectionView.selectedIndex = self.viewModel.selectedChallengeIndex
             return cell
         })
     }
@@ -240,7 +240,8 @@ struct CertifyViewController_Preview: PreviewProvider {
                 viewModel: CertifyViewModel(
                     usecase: DefaultCertifyUsecase(
                         repository: DefaultCertifyRepository()
-                    )
+                    ),
+                    selectedChallengeId: nil
                 )
             )
                 .toPreview()

--- a/Cider/Cider/Presentation/ChallengeDetail/ViewModel/ChallengeDetailViewModel.swift
+++ b/Cider/Cider/Presentation/ChallengeDetail/ViewModel/ChallengeDetailViewModel.swift
@@ -17,7 +17,7 @@ final class ChallengeDetailViewModel: ViewModelType {
     }
     
     private var usecase: ChallengeDetailUsecase
-    private let challengeId: Int
+    let challengeId: Int
     
     var state: AnyPublisher<ViewModelState, Never> { currentState.compactMap { $0 }.eraseToAnyPublisher() }
     var currentState: CurrentValueSubject<ViewModelState?, Never> = .init(nil)

--- a/Cider/Cider/Presentation/ChallengeDetail/Views/ChallengeDetailViewController.swift
+++ b/Cider/Cider/Presentation/ChallengeDetail/Views/ChallengeDetailViewController.swift
@@ -1092,7 +1092,8 @@ private extension ChallengeDetailViewController {
             viewModel: MyCertifyViewModel(
                 usecase: DefaultMyCertifyUsecase(
                     repository: DefaultMyCertifyRepository()
-                )
+                ),
+                selectedChallengeId: viewModel.challengeId
             )
         )
         self.navigationController?.pushViewController(viewController, animated: true)
@@ -1143,7 +1144,8 @@ private extension ChallengeDetailViewController {
             viewModel: CertifyViewModel(
                 usecase: DefaultCertifyUsecase(
                     repository: DefaultCertifyRepository()
-                )
+                ),
+                selectedChallengeId: viewModel.challengeId
             )
         )
         self.navigationController?.pushViewController(viewController, animated: true)

--- a/Cider/Cider/Presentation/ChallengeDetail/Views/ChallengeDetailViewController.swift
+++ b/Cider/Cider/Presentation/ChallengeDetail/Views/ChallengeDetailViewController.swift
@@ -172,7 +172,7 @@ private extension ChallengeDetailViewController {
             bottomView.heightAnchor.constraint(equalToConstant: 56),
             bottomButton.centerYAnchor.constraint(equalTo: bottomView.centerYAnchor),
             bottomButton.leadingAnchor.constraint(equalTo: heartButton.trailingAnchor, constant: 16),
-            bottomButton.widthAnchor.constraint(equalToConstant: 262),
+            bottomButton.widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width*0.727),
             heartButton.heightAnchor.constraint(equalToConstant: 24),
             heartButton.widthAnchor.constraint(equalToConstant: 24),
             heartButton.topAnchor.constraint(equalTo: bottomView.topAnchor, constant: 10),

--- a/Cider/Cider/Presentation/Mypage/ViewModels/MyCertifyViewModel.swift
+++ b/Cider/Cider/Presentation/Mypage/ViewModels/MyCertifyViewModel.swift
@@ -23,9 +23,11 @@ final class MyCertifyViewModel: ViewModelType {
     var participateChallengeTitles: [String] = []
     var feedItems: [Item] = []
     var challengeTitle: String = ""
+    var selectedChallengeId: Int?
     
-    init(usecase: MyCertifyUsecase) {
+    init(usecase: MyCertifyUsecase, selectedChallengeId: Int?) {
         self.usecase = usecase
+        self.selectedChallengeId = selectedChallengeId
         setNotificationCenter()
     }
     
@@ -69,7 +71,19 @@ private extension MyCertifyViewModel {
                     participateChallengeIds.append(challenge.challengeId)
                     participateChallengeTitles.append(challenge.challengeName)
                 }
-                try await getMyCertify(challengeId: participateChallengeIds[0])
+                if let selectedChallengeId {
+                    var index = 0
+                    for i in 0..<participateChallengeIds.count {
+                        if participateChallengeIds[i] == selectedChallengeId {
+                            index = i
+                            break
+                        }
+                    }
+                    try await getMyCertify(challengeId: participateChallengeIds[index])
+                } else {
+                    try await getMyCertify(challengeId: participateChallengeIds[0])
+                }
+               
             }
         }
     }

--- a/Cider/Cider/Presentation/Mypage/Views/MypageViewController.swift
+++ b/Cider/Cider/Presentation/Mypage/Views/MypageViewController.swift
@@ -204,7 +204,8 @@ private extension MypageViewController {
             viewModel: MyCertifyViewModel(
                 usecase: DefaultMyCertifyUsecase(
                     repository: DefaultMyCertifyRepository()
-                )
+                ),
+                selectedChallengeId: nil
             )
         )
         viewController.hidesBottomBarWhenPushed = true

--- a/Cider/Cider/Presentation/Writing/Views/WritingViewController.swift
+++ b/Cider/Cider/Presentation/Writing/Views/WritingViewController.swift
@@ -79,7 +79,8 @@ private extension WritingViewController {
                 viewModel: CertifyViewModel(
                     usecase: DefaultCertifyUsecase(
                         repository: DefaultCertifyRepository()
-                    )
+                    ),
+                    selectedChallengeId: nil
                 )
             )
             viewController.hidesBottomBarWhenPushed = true


### PR DESCRIPTION
### 📙 작업 내역

- [x] 챌린지 상세 바텀버튼 width 기기별 대응
- [ ] 챌린지 상세에서 챌린지 인증, 인증글 볼 때 해당 챌린지 자동 선택되게 구현


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트



### 📝 리뷰 노트

- 내용기재

### 🏞️ 스크린샷

> 작업 내용과 관련된 화면을 추가합니다.
